### PR TITLE
Make the modifications arrays for each release be one dimensional

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -96,7 +96,7 @@ function buildVersionLog(name, release) {
 
   var header = buildHeader([{level: 3}, name]);
   var list = map(log, (entry) => {
-    return '- ' + indent(buildElementList(entry), 2).trim();
+    return '- ' + indent(buildElement(entry), 2).trim();
   });
   return header + list.join('\n') + '\n\n';
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -100,7 +100,7 @@ function extractBulletList(md) {
     return null;
 
   return _.map(list.slice(1), function(item) {
-    return item.slice(1);
+    return item.slice(1)[0];
   });
 }
 

--- a/test/parser_tests.js
+++ b/test/parser_tests.js
@@ -1,0 +1,54 @@
+import path           from 'path'
+import {readFileSync} from 'fs'
+import {expect}       from 'chai'
+import {parse}        from '../src'
+import {find}         from 'lodash-node'
+
+function readFixture(name) {
+  var p = path.resolve('test', 'fixtures', name) + '.md'
+  return readFileSync(p, {encoding: 'utf8'})
+}
+
+describe('Parser', function () {
+  beforeEach(function () {
+    var source = readFixture('all');
+    this.parsed = parse(source);
+  });
+
+  describe('returned object', function () {
+    //describe('prelude property', function () {
+    //});
+
+    describe('releases property', function () {
+      describe('upcoming version', function () {
+        beforeEach(function () {
+          this.upcoming = find(this.parsed.releases, {version: 'upcoming'} );
+        });
+
+        it('has a changed property will all the additions', function () {
+          var expectedAdded = ['one added'];
+
+          expect(this.upcoming.Added).to.deep.equal(expectedAdded);
+        });
+
+        it('has an added property with all the changes', function () {
+          var expectedChanged =  [
+            'this has changed',
+            'this item continues\nin the next line'
+          ];
+
+          expect(this.upcoming.Changed).to.deep.equal(expectedChanged);
+        });
+
+        it('has an added property with all the changes', function () {
+          var expectedRemoved =  ['gone :('];
+
+          expect(this.upcoming.Removed).to.deep.equal(expectedRemoved);
+        });
+      });
+    });
+
+    //describe('epilogue property', function () {
+    //});
+  });
+});


### PR DESCRIPTION
Before this change we had this situation:

``` js
upcoming.Changed : [['nested change'], ['another change']]
upcoming.Removed :[['nested removal'], ['another removal']]
upcoming.Added : [['nested addition']]
```

After the change we have something like this

``` js
upcoming.Changed : ['nested change', 'another change']
upcoming.Removed : ['nested removal', 'another removal']
upcoming.Added : ['nested addition']
```

Which follows the example given in the README file and also makes more
sense
