### PR TITLE
Support for adding all change types to an upcoming release

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,15 +43,19 @@ Changelog.prototype.getRelease = function(version) {
 
 
 Changelog.prototype.addUpcomingChange = function(desc) {
+  this.addUpcoming('Changed', desc);
+};
+
+Changelog.prototype.addUpcoming = function(type, desc) {
   var upcoming = this.getRelease('upcoming');
   if (!upcoming) {
     upcoming = { version: 'upcoming' };
     this.releases.unshift(upcoming);
   }
 
-  var changes = upcoming.Changed;
+  var changes = upcoming[type];
   if (!changes) {
-    upcoming.Changed = changes = [];
+    upcoming[type] = changes = [];
   }
 
   changes.push([desc]);


### PR DESCRIPTION
Added a generic `addUpcoming` function to allow adding different types to an upcoming release.
