### PR TITLE
Support for links

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -40,16 +40,20 @@ function buildElement(el) {
     return el;
 
   var tagName = el.shift();
-  if (tagName == 'header')
-    return buildHeader(el);
-  else if (tagName == 'para')
-    return buildPara(el);
-  else if (tagName == 'inlinecode')
-    return buildAndSurroundElementList('`', el);
-  else if (tagName == 'em')
-    return buildAndSurroundElementList('*', el);
-  else
-    throw new Error(`Unknown tag ${tagName}`);
+
+  switch (tagName) {
+    case 'header':
+      return buildHeader(el);
+    case 'para':
+      return buildPara(el);
+    case 'inlinecode':
+      return buildAndSurroundElementList('`', el);
+    case 'em':
+      return buildAndSurroundElementList('*', el);
+    default:
+      throw new Error(`Unknown tag ${tagName}`);
+  }
+}
 }
 
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -50,10 +50,16 @@ function buildElement(el) {
       return buildAndSurroundElementList('`', el);
     case 'em':
       return buildAndSurroundElementList('*', el);
+    case 'link':
+      return buildLink(el);
     default:
       throw new Error(`Unknown tag ${tagName}`);
   }
 }
+
+
+function buildLink(el) {
+  return `[${el[1]}](${el[0].href})`;
 }
 
 

--- a/test/fixtures/all.md
+++ b/test/fixtures/all.md
@@ -23,6 +23,10 @@ The prelude
 ### Security
 - to invite users to upgrade in case of vulnerabilities.
 
+## v1.0.1
+### Fixed
+- Parsing of links e.g. [#8](https://github.com/contentful-labs/keepachangelog/pull/8)
+
 ## v1.0.0
 ### Added
 - the initial release


### PR DESCRIPTION
Just noticed that you cannot use the lib to parse a changelog that contains links. Not sure why there is any implementation work necessary but so what :)
